### PR TITLE
Use headers returned by @mapbox/mbtiles

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -3,7 +3,9 @@ import { parseTilePath } from "./lib";
 it("should parse path", () => {
   const params = parseTilePath({x: "11", y: "12", z: "10"});
   expect(params).not.toBeNull();
-  // @ts-ignore
+  if (!params) {
+    throw new Error('params is null')
+  }
   const { z, x, y } = params;
   expect(z).toEqual("10");
   expect(x).toEqual("11");

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -26,10 +26,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   const [y, ] = origY.split(".");
 
   try {
-    const tile = await getTile(mbtiles, z, x, y);
+    const { data, headers } = await getTile(mbtiles, z, x, y);
     return {
       headers: {
-        "Content-Type": "application/vnd.mapbox-vector-tile",
+        ...headers,
         "Cache-Control": "public, max-age=3600",
         "Access-Control-Allow-Origin": "*",
         "X-Frame-Options": "SAMEORIGIN",
@@ -38,7 +38,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       },
       isBase64Encoded: true,
       statusCode: 200,
-      body: tile.toString("base64"),
+      body: data.toString("base64"),
     };
   } catch (error) {
     // No content


### PR DESCRIPTION
`headers` に @mapbox/tiletype で認識されたヘッダーが埋め込まれているので、そのまま使う

https://github.com/mapbox/tiletype/blob/master/index.js#L52

Closes #7 