### PR TITLE
update tile.json and metadata.json

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -59,7 +59,7 @@ const getMBTilesInstance = (filename: string) => {
     try {
       const _stat = fs.statSync(localFilePath);
       cacheKey = _stat.size + '-' + Number(_stat.mtime) + '-' + filename;
-    } catch (e) {
+    } catch (e: any) {
       if (e.code === "ENOENT") {
         return reject(e);
       }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -27,20 +27,33 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
   let body: { [key: string]: any };
   if (event.routeKey === "GET /{ver}/metadata.json") {
     body = {
-      ...meta,
-      tiles: [],
+      name: meta.name,
+      description: meta.description,
+      version: meta.version,
+      minzoom: meta.minzoom,
+      maxzoom: meta.maxzoom,
+      center: meta.center,
+      bounds: meta.bounds,
+      type: meta.type,
+      format: meta.format,
+      json: {
+        vector_layers: JSON.stringify(meta.vector_layers)
+      }
     };
   } else if (event.routeKey === "GET /{ver}/tiles.json") {
     body = {
-      attribution: meta.attribution,
-      bounds: meta.bounds,
+      tilejson: "3.0.0",
+      name: meta.name,
       description: meta.description,
-      format: meta.format,
-      scheme: meta.scheme,
       version: meta.version,
-      maxzoom: meta.maxzoom,
+      attribution: meta.attribution,
+      scheme: meta.scheme,
+      format: meta.format,
       minzoom: meta.minzoom,
+      maxzoom: meta.maxzoom,
+      bounds: meta.bounds,
       center: meta.center,
+      vector_layers: meta.vector_layers,
       tiles,
     }
   } else {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -26,38 +26,18 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
 
   let body: { [key: string]: any };
   if (event.routeKey === "GET /{ver}/metadata.json") {
+    // metadata.json can be used to introspect a tileset without requiring authorization or
+    // triggering a billable page-load.
     body = {
-      name: meta.name,
-      description: meta.description,
-      version: meta.version,
-      minzoom: meta.minzoom,
-      maxzoom: meta.maxzoom,
-      center: meta.center,
-      bounds: meta.bounds,
-      type: meta.type,
-      format: meta.format,
-      json: {
-        vector_layers: JSON.stringify(meta.vector_layers)
-      }
+      ...meta,
+      tiles: [],
     };
   } else if (event.routeKey === "GET /{ver}/tiles.json") {
-    /**
-     * Definition of TileJSON v3.0.0
-     * see https://github.com/mapbox/tilejson-spec/blob/master/3.0.0/schema.json
-     */
+    // tiles.json is mainly used for loading and viewing tiles, but some tools use this to
+    // introspect and generate base styles, so important keys such as vector_layers are
+    // preserved.
     body = {
-      tilejson: "3.0.0",
-      name: meta.name,
-      description: meta.description,
-      version: meta.version,
-      attribution: meta.attribution,
-      scheme: meta.scheme,
-      format: meta.format,
-      minzoom: meta.minzoom,
-      maxzoom: meta.maxzoom,
-      bounds: meta.bounds,
-      center: meta.center,
-      vector_layers: meta.vector_layers,
+      ...meta,
       tiles,
     }
   } else {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -41,6 +41,10 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
       }
     };
   } else if (event.routeKey === "GET /{ver}/tiles.json") {
+    /**
+     * Definition of TileJSON v3.0.0
+     * see https://github.com/mapbox/tilejson-spec/blob/master/3.0.0/schema.json
+     */
     body = {
       tilejson: "3.0.0",
       name: meta.name,


### PR DESCRIPTION
`tiles.json` と `metada.json` のデータ形式を更新しました。

## `tiles.json`

### 追加項目
- tilejson
- name
- vector_layers

### 参考
 https://github.com/mapbox/tilejson-spec/tree/master/3.0.0

## metadata.json

metada.json の `json`の値は、`mbutil` や `tippecanoe` によって異なっていたので、`Charites` に合わせました。

### 参考
https://github.com/unvt/charites/blob/main/src/types/metadatajson.ts